### PR TITLE
fix param types on methods in _EmptyVersion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.packages
 packages
 pubspec.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.2
+
+* Make the package analyze under strong mode and compile with the DDC (Dart Dev
+  Compiler). Fix two issues with a private subclass of `VersionConstraint`
+  having different types for overridden methods.
+
 # 1.2.1
 
 * Allow version ranges like `>=1.2.3-dev.1 <1.2.3` to match pre-release versions

--- a/lib/src/version_constraint.dart
+++ b/lib/src/version_constraint.dart
@@ -209,8 +209,8 @@ class _EmptyVersion implements VersionConstraint {
   bool get isEmpty => true;
   bool get isAny => false;
   bool allows(Version other) => false;
-  bool allowsAll(Version other) => other.isEmpty;
-  bool allowsAny(Version other) => false;
+  bool allowsAll(VersionConstraint other) => other.isEmpty;
+  bool allowsAny(VersionConstraint other) => false;
   VersionConstraint intersect(VersionConstraint other) => this;
   VersionConstraint union(VersionConstraint other) => other;
   String toString() => '<empty>';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pub_semver
-version: 1.2.1
+version: 1.2.2
 author: Dart Team <misc@dartlang.org>
 description: >
  Versions and version constraints implementing pub's versioning policy. This


### PR DESCRIPTION
Fix two type issues found by ddc - the params of two methods differed from what was defined in the parent class:

```
Invalid override. The type of _EmptyVersion.allowsAll ((Version) → bool) is not a subtype of VersionConstraint.allowsAll ((VersionConstraint) → bool). (package:pub_semver/src/version_constraint.dart, line 212, col 3)
Invalid override. The type of _EmptyVersion.allowsAny ((Version) → bool) is not a subtype of VersionConstraint.allowsAny ((VersionConstraint) → bool). (package:pub_semver/src/version_constraint.dart, line 213, col 3)
```

(see also https://github.com/dart-atom/dartlang/issues/327)
