### PR TITLE
Fix strong mode error in test

### DIFF
--- a/test/version_range_test.dart
+++ b/test/version_range_test.dart
@@ -327,10 +327,12 @@ main() {
       var a = new VersionRange(min: v123, max: v250);
       var b = new VersionRange(min: v200, max: v300);
       var intersect = a.intersect(b);
-      expect(intersect.min, equals(v200));
-      expect(intersect.max, equals(v250));
-      expect(intersect.includeMin, isFalse);
-      expect(intersect.includeMax, isFalse);
+      expect(intersect, new isInstanceOf<VersionRange>());
+      var intersectRange = intersect as VersionRange;
+      expect(intersectRange.min, equals(v200));
+      expect(intersectRange.max, equals(v250));
+      expect(intersectRange.includeMin, isFalse);
+      expect(intersectRange.includeMax, isFalse);
     });
 
     test('a non-overlapping range allows no versions', () {


### PR DESCRIPTION
Currently there are a few strong mode errors in the tests:

```none
$ dartanalyzer --strong test/
Analyzing [test/]...
[error] The getter 'min' isn't defined for the class 'VersionConstraint'. (/Users/srawlins/code/dart-pub_semver/test/version_range_test.dart, line
 330, col 24)
[error] The getter 'max' isn't defined for the class 'VersionConstraint'. (/Users/srawlins/code/dart-pub_semver/test/version_range_test.dart, line
 331, col 24)
[error] The getter 'includeMin' isn't defined for the class 'VersionConstraint'. (/Users/srawlins/code/dart-pub_semver/test/version_range_test.dar
t, line 332, col 24)
[error] The getter 'includeMax' isn't defined for the class 'VersionConstraint'. (/Users/srawlins/code/dart-pub_semver/test/version_range_test.dar
t, line 333, col 24)
4 errors found.
```

This PR fixes them.