### PR TITLE
Fix a crashing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.3
+
+* Fix a bug where `VersionRange.difference()` with a union constraint that
+  covered the entire range would crash.
+
 # 1.3.2
 
 * Fix a checked-mode error in `VersionRange.difference()`.

--- a/lib/src/version_range.dart
+++ b/lib/src/version_range.dart
@@ -379,7 +379,9 @@ class VersionRange implements Comparable<VersionRange>, VersionConstraint {
         if (strictlyHigher(range, current)) break;
 
         var difference = current.difference(range);
-        if (difference is VersionUnion) {
+        if (difference.isEmpty) {
+          return VersionConstraint.empty;
+        } else if (difference is VersionUnion) {
           // If [range] split [current] in half, we only need to continue
           // checking future ranges against the latter half.
           assert(difference.ranges.length == 2);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pub_semver
-version: 1.3.3-dev
+version: 1.3.3
 author: Dart Team <misc@dartlang.org>
 description: >
  Versions and version constraints implementing pub's versioning policy. This

--- a/test/version_range_test.dart
+++ b/test/version_range_test.dart
@@ -606,6 +606,14 @@ main() {
             new VersionRange(min: v130, max: v140)
           ])));
     });
+
+    test("with a version union that covers the whole range, returns empty", () {
+      expect(
+          new VersionRange(min: v114, max: v140).difference(
+              new VersionConstraint.unionOf(
+                  [v003, new VersionRange(min: v010)])),
+          equals(VersionConstraint.empty));
+    });
   });
 
   test('isEmpty', () {


### PR DESCRIPTION
VersionRange.difference() with a VersionUnion didn't expect to get an
empty constraint, but it was possible to do so.

Closes #18