### PR TITLE
Fix more pre-release constraint bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.7
+
+* Fix more bugs with `VersionRange.intersect()`, `VersionRange.difference()`,
+  and `VersionRange.union()` involving version ranges with pre-release maximums.
+
 # 1.3.6
 
 * Fix a bug where constraints that only allowed pre-release versions would be

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -32,9 +32,11 @@ bool allowsHigher(VersionRange range1, VersionRange range2) {
   if (range1.max == null) return range2.max != null;
   if (range2.max == null) return false;
 
-  // `<1.0.0-dev.1` allows `1.0.0-dev.0` which is higher than any versions
-  // allowed by `<1.0.0`.
+  // `<1.0.0-dev.1` allows higher versions than `<1.0.0`, such as `1.0.0-dev.0`.
   if (disallowedByPreRelease(range2, range1.max)) return true;
+
+  // `<1.0.0` doesn't allow any versions higher than `<1.0.0-dev`.
+  if (disallowedByPreRelease(range1, range2.max)) return false;
 
   var comparison = range1.max.compareTo(range2.max);
   if (comparison == 1) return true;
@@ -46,7 +48,11 @@ bool allowsHigher(VersionRange range1, VersionRange range2) {
 /// [range2].
 bool strictlyLower(VersionRange range1, VersionRange range2) {
   if (range1.max == null || range2.min == null) return false;
+
+  // `<1.0.0` doesn't allow any versions allowed by `>=1.0.0-dev.0`.
   if (disallowedByPreRelease(range1, range2.min)) return true;
+
+  //if (disallowedByPreRelease(range2, range1.min)) return true;
 
   var comparison = range1.max.compareTo(range2.min);
   if (comparison == -1) return true;

--- a/lib/src/version_range.dart
+++ b/lib/src/version_range.dart
@@ -215,29 +215,24 @@ class VersionRange implements Comparable<VersionRange>, VersionConstraint {
         return new VersionConstraint.unionOf([this, other]);
       }
 
-      var unionMin = min;
-      var unionIncludeMin = includeMin;
-      var unionMax = max;
-      var unionIncludeMax = includeMax;
-
-      if (unionMin == null) {
-        // Do nothing.
-      } else if (other.min == null || other.min < min) {
+      Version unionMin;
+      bool unionIncludeMin;
+      if (allowsLower(this, other)) {
+        unionMin = this.min;
+        unionIncludeMin = this.includeMin;
+      } else {
         unionMin = other.min;
         unionIncludeMin = other.includeMin;
-      } else if (min == other.min && other.includeMin) {
-        // If the edges are the same but one is inclusive, make it inclusive.
-        unionIncludeMin = true;
       }
 
-      if (unionMax == null) {
-        // Do nothing.
-      } else if (other.max == null || other.max > max) {
+      Version unionMax;
+      bool unionIncludeMax;
+      if (allowsHigher(this, other)) {
+        unionMax = this.max;
+        unionIncludeMax = this.includeMax;
+      } else {
         unionMax = other.max;
         unionIncludeMax = other.includeMax;
-      } else if (max == other.max && other.includeMax) {
-        // If the edges are the same but one is inclusive, make it inclusive.
-        unionIncludeMax = true;
       }
 
       return new VersionRange(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pub_semver
-version: 1.3.6
+version: 1.3.7
 author: Dart Team <misc@dartlang.org>
 description: >
  Versions and version constraints implementing pub's versioning policy. This

--- a/test/version_range_test.dart
+++ b/test/version_range_test.dart
@@ -469,6 +469,13 @@ main() {
               .intersect(new VersionConstraint.parse(">=2.0.0-dev")),
           equals(VersionConstraint.empty));
     });
+
+    test("with a range with a pre-release max, returns the original", () {
+      expect(
+          new VersionRange(max: v200)
+              .intersect(new VersionConstraint.parse("<2.0.0-dev")),
+          equals(new VersionRange(max: v200)));
+    });
   });
 
   group('union()', () {
@@ -557,6 +564,14 @@ main() {
       expect(result, allows(new Version.parse("2.0.0-dev")));
       expect(result, allows(new Version.parse("2.0.0-dev.1")));
       expect(result, allows(new Version.parse("2.0.0")));
+    });
+
+    test("with a range with a pre-release max, returns the larger constraint",
+        () {
+      expect(
+          new VersionRange(max: v200)
+              .union(new VersionConstraint.parse("<2.0.0-dev")),
+          equals(new VersionConstraint.parse("<2.0.0-dev")));
     });
   });
 
@@ -729,6 +744,13 @@ main() {
           new VersionRange(max: v200)
               .difference(new VersionConstraint.parse(">=2.0.0-dev")),
           equals(new VersionRange(max: v200)));
+    });
+
+    test("with a range with a pre-release max, returns null", () {
+      expect(
+          new VersionRange(max: v200)
+              .difference(new VersionConstraint.parse("<2.0.0-dev")),
+          equals(VersionConstraint.empty));
     });
   });
 


### PR DESCRIPTION
I hadn't thought to test version ranges with max pre-release
constraints, but they turn out to be relevant in some situations.

Closes #20