### PR TITLE
Stronger version validation

### DIFF
--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -4,7 +4,11 @@
 
 /// Regex that matches a version number at the beginning of a string.
 final START_VERSION = new RegExp(r'^' // Start at beginning.
-    r'(\d+).(\d+).(\d+)' // Version number.
+    r'(0|[1-9][0-9]*)' // Major
+    r'\.'
+    r'(0|[1-9][0-9]*)' // Minor
+    r'\.'
+    r'(0|[1-9][0-9]*)' // Patch
     r'(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Pre-release.
     r'(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?'); // Build.
 

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -312,7 +312,7 @@ main() {
     expect(() => new Version.parse('1.00.0'), throwsFormatException);
     expect(() => new Version.parse('1.0.00'), throwsFormatException);
     expect(() => new Version.parse('01.0.0'), throwsFormatException);
-    expect(() => new Version.parse('001.02.0003-01.dev+pre.002'), 
+    expect(() => new Version.parse('001.02.0003-01.dev+pre.002'),
         throwsFormatException);
   });
 

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -312,6 +312,9 @@ main() {
     expect(() => new Version.parse('1.3-pre'), throwsFormatException);
     expect(() => new Version.parse('1.3+build'), throwsFormatException);
     expect(() => new Version.parse('1.3+bu?!3ild'), throwsFormatException);
+    expect(() => new Version.parse('1.00.0'), throwsFormatException);
+    expect(() => new Version.parse('1.0.00'), throwsFormatException);
+    expect(() => new Version.parse('01.0.0'), throwsFormatException);
   });
 
   group('toString()', () {

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -312,7 +312,8 @@ main() {
     expect(() => new Version.parse('1.00.0'), throwsFormatException);
     expect(() => new Version.parse('1.0.00'), throwsFormatException);
     expect(() => new Version.parse('01.0.0'), throwsFormatException);
-    expect(() => new Version.parse('001.02.0003-01.dev+pre.002'), throwsFormatException);
+    expect(() => new Version.parse('001.02.0003-01.dev+pre.002'), 
+        throwsFormatException);
   });
 
   group('toString()', () {

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -114,6 +114,13 @@ main() {
         }
       }
     });
+    
+    test('equality', () {
+      expect(
+          new Version.parse('1.2.3-01'), equals(new Version.parse('1.2.3-1')));
+      expect(
+          new Version.parse('1.2.3+01'), equals(new Version.parse('1.2.3+1')));
+    });    
   });
 
   test('allows()', () {
@@ -305,6 +312,7 @@ main() {
     expect(() => new Version.parse('1.00.0'), throwsFormatException);
     expect(() => new Version.parse('1.0.00'), throwsFormatException);
     expect(() => new Version.parse('01.0.0'), throwsFormatException);
+    expect(() => new Version.parse('001.02.0003-01.dev+pre.002'), throwsFormatException);
   });
 
   group('toString()', () {

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -114,13 +114,13 @@ main() {
         }
       }
     });
-    
+
     test('equality', () {
       expect(
           new Version.parse('1.2.3-01'), equals(new Version.parse('1.2.3-1')));
       expect(
           new Version.parse('1.2.3+01'), equals(new Version.parse('1.2.3+1')));
-    });    
+    });
   });
 
   test('allows()', () {

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -114,16 +114,6 @@ main() {
         }
       }
     });
-
-    test('equality', () {
-      expect(new Version.parse('01.2.3'), equals(new Version.parse('1.2.3')));
-      expect(new Version.parse('1.02.3'), equals(new Version.parse('1.2.3')));
-      expect(new Version.parse('1.2.03'), equals(new Version.parse('1.2.3')));
-      expect(
-          new Version.parse('1.2.3-01'), equals(new Version.parse('1.2.3-1')));
-      expect(
-          new Version.parse('1.2.3+01'), equals(new Version.parse('1.2.3+1')));
-    });
   });
 
   test('allows()', () {
@@ -331,11 +321,6 @@ main() {
           equals('1.2.3+build.1'));
       expect(new Version(1, 2, 3, pre: 'pre', build: 'bui').toString(),
           equals('1.2.3-pre+bui'));
-    });
-
-    test('preserves leading zeroes', () {
-      expect(new Version.parse('001.02.0003-01.dev+pre.002').toString(),
-          equals('001.02.0003-01.dev+pre.002'));
     });
   });
 }


### PR DESCRIPTION
I found that here https://semver.org/#spec-item-2 is defined that "A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and MUST NOT contain leading zeroes." So here's the fix, I've added stronger validation for the version part.