### PR TITLE
Reference https://semver.org/spec/v2.0.0-rc.1.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Handles version numbers and version constraints in the same way that [pub][]
-does. The semantics here very closely follow the [Semantic Versioning][semver]
-spec. It differs from semver in a few corner cases:
+does. The semantics here very closely follow the
+[Semantic Versioning spec version 2.0.0-rc.1][semver]. It differs from semver
+in a few corner cases:
 
  *  **Version ordering does take build suffixes into account.** This is unlike
     semver 2.0.0 but like earlier versions of semver. Version `1.2.3+1` is
@@ -94,5 +95,5 @@ spec. It differs from semver in a few corner cases:
     constraint greater than or equal to a given version, but less than its next
     breaking one.
 
-[pub]: http://pub.dartlang.org/
-[semver]: http://semver.org/
+[pub]: https://pub.dev
+[semver]: https://semver.org/spec/v2.0.0-rc.1.html


### PR DESCRIPTION
https://dart.dev/tools/pub/versioning#semantic-versions
> To make this work, then, we need to come up with that set of promises. Fortunately, other smart people have done the work of figuring this all out and named it [semantic versioning](http://semver.org/spec/v2.0.0-rc.1.html).

References: `http://semver.org/spec/v2.0.0-rc.1.html`.

-----
At first I thought it was stale documentation, but comparing `2.0.0-rc.1` to `2.0.0` I noticed differences around:
A) Leading zeros, notably being tolerated by `2.0.0-rc.1`, while explicitly forbidden by `2.0.0`.
B) Description of ordering pre-releases.

Since (A) seems to be allowed (covered by tests) in `pub_semver`:
https://github.com/dart-lang/pub_semver/blob/7edd4f081a6b9ce456e1cb4240e1bb8720cb7d0a/test/version_test.dart#L328-L331

And in case (B) we're following `2.0.0-rc.1` in tests:
https://github.com/dart-lang/pub_semver/blob/7edd4f081a6b9ce456e1cb4240e1bb8720cb7d0a/test/version_test.dart#L71-L89
And reference this in the implementation as well:
https://github.com/dart-lang/pub_semver/blob/7edd4f081a6b9ce456e1cb4240e1bb8720cb7d0a/lib/src/version.dart#L312-L316

I am now inclined to think that we're implementing `2.0.0-rc.1`, let's make sure that's clearly specified.