### PR TITLE
Replace use of int.parse with int.tryParse

### DIFF
--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -152,12 +152,8 @@ class Version implements VersionConstraint, VersionRange {
   /// Identifiers that are numeric are converted to numbers.
   static List _splitParts(String text) {
     return text.split('.').map((part) {
-      try {
-        return int.parse(part);
-      } on FormatException {
-        // Not a number.
-        return part;
-      }
+      // Return an integer part if possible, otherwise return the string as-is
+      return int.tryParse(part) ?? part;
     }).toList();
   }
 


### PR DESCRIPTION
By replacing `int.parse` with `int.tryParse`, exceptions will no longer be thrown if the version part is a non-integer. This avoids triggering the debugger if set to break on "All Exceptions".

Fixes #42