### PR TITLE
Annotate `Version` with `@sealed`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1-dev
+- Annotated `Version` with `@sealed` to discourage users from implementing the
+  interface.
+
 # 2.0.0
 
 - Stable null safety release.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart' show sealed;
 
 import 'patterns.dart';
 import 'version_constraint.dart';
@@ -14,6 +15,7 @@ import 'version_range.dart';
 final _equality = const IterableEquality();
 
 /// A parsed semantic version number.
+@sealed
 class Version implements VersionConstraint, VersionRange {
   /// No released version: i.e. "0.0.0".
   static Version get none => Version(0, 0, 0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pub_semver
-version: 2.0.0
+version: 2.0.1-dev
 description: >-
  Versions and version constraints implementing pub's versioning policy. This
  is very similar to vanilla semver, with a few corner cases.
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
+  meta: ^1.3.0
 
 dev_dependencies:
   test: ^1.16.0-nullsafety.1


### PR DESCRIPTION
This adds a dependency on `package:meta`.

I don't think anybody is implementing the `Version` interface, since it has factory constructors, so you can't just extend it.