### PR TITLE
Prepare to merge null safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - dev
+- dev
 
 jobs:
   include:
@@ -18,4 +18,4 @@ branches:
 
 cache:
  directories:
-   - $HOME/.pub-cache
+ - $HOME/.pub-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.5.0-nullsafety
+# 1.5.0-nullsafety-dev
 
-- `Version.primary` now throws `StateError` if the `versions` argument is empty. 
+- Migrate to null safety.
+- `Version.primary` now throws `StateError` if the `versions` argument is empty.
 
 # 1.4.4
 

--- a/lib/src/version_range.dart
+++ b/lib/src/version_range.dart
@@ -430,41 +430,39 @@ class VersionRange implements Comparable<VersionRange>, VersionConstraint {
   String toString() {
     var buffer = StringBuffer();
 
-    final theMin = min;
-    if (theMin != null) {
+    final min = this.min;
+    if (min != null) {
       buffer..write(includeMin ? '>=' : '>')..write(min);
     }
 
-    final theMax = max;
+    final max = this.max;
 
-    if (theMax != null) {
-      if (theMin != null) buffer.write(' ');
+    if (max != null) {
+      if (min != null) buffer.write(' ');
       if (includeMax) {
         buffer..write('<=')..write(max);
       } else {
         buffer.write('<');
-        if (theMax.isFirstPreRelease) {
+        if (max.isFirstPreRelease) {
           // Since `"<$max"` would parse the same as `"<$max-0"`, we just emit
           // `<$max` to avoid confusing "-0" suffixes.
-          buffer.write('${theMax.major}.${theMax.minor}.${theMax.patch}');
+          buffer.write('${max.major}.${max.minor}.${max.patch}');
         } else {
           buffer.write(max);
 
           // If `">=$min <$max"` would parse as `">=$min <$max-0"`, add `-*` to
           // indicate that actually does allow pre-release versions.
-          var minIsPreReleaseOfMax = theMin != null &&
-              theMin.isPreRelease &&
-              equalsWithoutPreRelease(theMin, theMax);
-          if (!theMax.isPreRelease &&
-              theMax.build.isEmpty &&
-              !minIsPreReleaseOfMax) {
+          var minIsPreReleaseOfMax = min != null &&
+              min.isPreRelease &&
+              equalsWithoutPreRelease(min, max);
+          if (!max.isPreRelease && max.build.isEmpty && !minIsPreReleaseOfMax) {
             buffer.write('-∞');
           }
         }
       }
     }
 
-    if (theMin == null && theMax == null) buffer.write('any');
+    if (min == null && max == null) buffer.write('any');
     return buffer.toString();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,3 +16,6 @@ dependencies:
 
 dev_dependencies:
   test: ^1.16.0-nullsafety.1
+
+dependency_overrides:
+  analyzer: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,15 @@
 name: pub_semver
-version: 1.5.0-nullsafety
+version: 2.0.0-nullsafety-dev
 
 description: >-
  Versions and version constraints implementing pub's versioning policy. This
  is very similar to vanilla semver, with a few corner cases.
 homepage: https://github.com/dart-lang/pub_semver
 
+publish_to: none # needs to be in allow list to run without experiment flag
+
 environment:
- sdk: '>=2.10.0-0 <2.10.0'
+ sdk: '>=2.11.0-0 <2.11.0'
 
 dependencies:
   collection: ^1.15.0-nullsafety.2


### PR DESCRIPTION
- Switch to a major version bump.
- Append a `-dev` to the version since we aren't publishing yet.
- Add `publish_to: none` for safety.
- Reformat `.travis.yml`. Indent list elements to the same position as
  the containing key. This matches yaml style in other Google files.
- Update SDK constraints to use the `2.11.0` dev SDKs.
- Renames some variables with noise word "the" to match the field name
  and avoid the shadowing with `this.`.