### PR TITLE
Add method to update a version constraint

### DIFF
--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -320,6 +320,11 @@ class Version implements VersionConstraint, VersionRange {
   }
 
   @override
+  VersionConstraint updateWith(Version version, {UpdateStrategy? strategy}) {
+    return version;
+  }
+
+  @override
   String toString() => _text;
 
   /// Compares a dot-separated component of two versions.

--- a/lib/src/version_union.dart
+++ b/lib/src/version_union.dart
@@ -212,6 +212,14 @@ class VersionUnion implements VersionConstraint {
       VersionConstraint.unionOf([this, other]);
 
   @override
+  VersionConstraint updateWith(Version version, {UpdateStrategy? strategy}) {
+    throw UnsupportedError(
+      'updateWith is not supported for VersionUnion as no valid version '
+      'constraints can be created from union versions',
+    );
+  }
+
+  @override
   bool operator ==(Object other) =>
       other is VersionUnion &&
       const ListEquality().equals(ranges, other.ranges);

--- a/test/version_constraint_test.dart
+++ b/test/version_constraint_test.dart
@@ -184,4 +184,15 @@ void main() {
       expect(constraint.toString(), equals('^0.7.2'));
     });
   });
+
+  group('updateWith()', () {
+    test('empty version', () {
+      var constraint = VersionConstraint.empty;
+
+      expect(
+        constraint.updateWith(Version(1, 2, 3)),
+        equals(VersionConstraint.compatibleWith(Version(1, 2, 3))),
+      );
+    });
+  });
 }

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -374,6 +374,15 @@ void main() {
       expect(() => Version.primary([]), throwsStateError);
     });
   });
+
+  test('updateWith()', () {
+    var constraint = Version(0, 1, 2);
+
+    expect(
+      constraint.updateWith(Version(1, 2, 3)),
+      equals(Version(1, 2, 3)),
+    );
+  });
 }
 
 Version _primary(List<String> input) =>

--- a/test/version_union_test.dart
+++ b/test/version_union_test.dart
@@ -480,4 +480,16 @@ void main() {
           ])));
     });
   });
+
+  test('updateWith()', () {
+    var constraint = VersionUnion.fromRanges([
+      Version(1, 2, 3),
+      Version(4, 5, 6),
+    ]);
+
+    expect(
+        () => constraint.updateWith(Version(7, 8, 9)),
+      throwsA(const TypeMatcher<UnsupportedError>()),
+    );
+  });
 }


### PR DESCRIPTION
This PR adds the functionality to update a version constraint to support the newest available version of a package.

I would like if this functionality would be added to the repository as it would make my ongoing work on dependabot support for Pub easier as I wouldn't have to reimplement the version parsing, updating completely from scratch and any future changes would automatically be supported.

See https://github.com/dependabot/dependabot-core/pull/3438 for the dependabot work.

--- 

In general, there will be two strategies for updating dependencies (as you can read in the code documentation).

One that tries to keep the minimum version and the other that updates to the newest possible version.
I am happy to discuss any change in implemented behavior.

For example, I am considering the behavior of `widenRanges`.
Do you think one of these make more sense:
* `>=1.2.0 <2.0.0` -> `>=2.0.0 <3.0.0` (with [version] `2.4.0`)
* `>=1.2.0 <2.0.0` -> `>=2.4.0 <3.0.0` (with [version] `2.4.0`)

than the currently implemented behavior:
* `>=1.2.0 <2.0.0` -> `>=1.2.0 <3.0.0` (with [version] `2.4.0`)