### PR TITLE
Fix minimum SDK constraint to 2.12.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: pub_semver
-version: 2.1.0
+version: 2.1.1-dev
 description: >-
  Versions and version constraints implementing pub's versioning policy. This
  is very similar to vanilla semver, with a few corner cases.
 repository: https://github.com/dart-lang/pub_semver
 
 environment:
- sdk: '>=2.12.0-0 <3.0.0'
+ sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   collection: ^1.15.0


### PR DESCRIPTION
`dart pub publish` will complain about prerelease SDK constraint, and they shouldn't be useful anymore.