### PR TITLE
Fix RegExp for version pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 2.1.1-dev
+# 2.1.1
+
+- Fixed the version parsing pattern to only accept dots between version
+  components.
 
 # 2.1.0
 - Added `Version.canonicalizedVersion` to help scrub leading zeros and highlight

--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -4,7 +4,7 @@
 
 /// Regex that matches a version number at the beginning of a string.
 final startVersion = RegExp(r'^' // Start at beginning.
-    r'(\d+).(\d+).(\d+)' // Version number.
+    r'(\d+)\.(\d+)\.(\d+)' // Version number.
     r'(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Pre-release.
     r'(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?'); // Build.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pub_semver
-version: 2.1.1-dev
+version: 2.1.1
 description: >-
  Versions and version constraints implementing pub's versioning policy. This
  is very similar to vanilla semver, with a few corner cases.

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -300,6 +300,7 @@ void main() {
         equals(Version(1, 0, 0, pre: 'rc-1', build: 'build-1')));
 
     expect(() => Version.parse('1.0'), throwsFormatException);
+    expect(() => Version.parse('1a2b3'), throwsFormatException);
     expect(() => Version.parse('1.2.3.4'), throwsFormatException);
     expect(() => Version.parse('1234'), throwsFormatException);
     expect(() => Version.parse('-2.3.4'), throwsFormatException);


### PR DESCRIPTION
## Description

The pattern for matching a version included "`.`" for the dots, instead of "`\.`", so it would accept "1a2b3" or "1|2|3" as a version (or any other single character). Updated to escape the dot.

## Tests
 - Added an expectation to disallow "1a2b3".

cc @kevmoo 