### PR TITLE
switch to using Object.hashAll

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.12.0, dev]
+        sdk: [2.14.0, dev]
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # 2.1.1-dev
 
 - Add markdown badges to the readme.
-- Switch to using `Object.hashAll` (from package:collection's
-  `ListEquality.hash`).
 - Increase the minimum SDK requirement to `2.14.0`.
 
 # 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 2.1.1-dev
 
 - Add markdown badges to the readme.
+- Switch to using `Object.hashAll` (from package:collection's
+  `ListEquality.hash`).
+- Increase the minimum SDK requirement to `2.14.0`.
 
 # 2.1.1
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -172,9 +172,7 @@ class Version implements VersionConstraint, VersionRange {
 
   @override
   int get hashCode =>
-      major ^
-      minor ^
-      patch ^
+      Object.hash(major, minor, patch) ^
       Object.hashAll(preRelease) ^
       Object.hashAll(build);
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -175,8 +175,8 @@ class Version implements VersionConstraint, VersionRange {
       major ^
       minor ^
       patch ^
-      _equality.hash(preRelease) ^
-      _equality.hash(build);
+      Object.hashAll(preRelease) ^
+      Object.hashAll(build);
 
   bool operator <(Version other) => compareTo(other) < 0;
   bool operator >(Version other) => compareTo(other) > 0;

--- a/lib/src/version_union.dart
+++ b/lib/src/version_union.dart
@@ -217,7 +217,7 @@ class VersionUnion implements VersionConstraint {
       const ListEquality<VersionRange>().equals(ranges, other.ranges);
 
   @override
-  int get hashCode => const ListEquality<VersionRange>().hash(ranges);
+  int get hashCode => Object.hashAll(ranges);
 
   @override
   String toString() => ranges.join(' or ');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 repository: https://github.com/dart-lang/pub_semver
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   collection: ^1.15.0


### PR DESCRIPTION
- switch to using Object.hashAll

I'm so-so on this change as the equals methods still use `ListEquality`, but the hash methods have switch to Object.hashAll.