### PR TITLE
Refactor away from deprecated error

### DIFF
--- a/lib/src/version_constraint.dart
+++ b/lib/src/version_constraint.dart
@@ -93,7 +93,7 @@ abstract class VersionConstraint {
         case '>':
           return VersionRange(min: version, includeMin: false);
       }
-      throw FallThroughError();
+      throw UnsupportedError(op);
     }
 
     // Try to parse the "^" operator followed by a version.


### PR DESCRIPTION
`FallThroughError` is deprecated, and scheduled for removal in 3.0