### PR TITLE
rev to 2.1.3 in preparation for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-# 2.1.3-dev
+# 2.1.3
 
+- Add type parameters to the signatures of the `Version.preRelease` and
+  `Version.build` fields (`List` ==> `List<Object>`).
+- Add additional lints to the set used to analyze this project; 
+  [#74](https://github.com/dart-lang/pub_semver/pull/74).
 - Require Dart 2.17.
 
 # 2.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - Add type parameters to the signatures of the `Version.preRelease` and
   `Version.build` fields (`List` ==> `List<Object>`).
-- Add additional lints to the set used to analyze this project; 
   [#74](https://github.com/dart-lang/pub_semver/pull/74).
 - Require Dart 2.17.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pub_semver
-version: 2.1.3-dev
+version: 2.1.3
 description: >-
  Versions and version constraints implementing pub's versioning policy. This
  is very similar to vanilla semver, with a few corner cases.


### PR DESCRIPTION
- update the changelog to capture the previous commit (it turns out that the API signature changes - which looked fairly minor - are effecting package consumers)
- rev to 2.1.3 in preparation for release
